### PR TITLE
Ignore gulpfile and karma configurations from the bower package

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -11,7 +11,8 @@
   "ignore": [
     "src",
     "test",
-    "Gruntfile.js",
+    "gulpfile.js",
+    "karma*.js",
     "**/.*"
   ],
   "dependencies": {},


### PR DESCRIPTION
Looks like `Gruntfile.js` did not get changed to `gulpfile.js` when Grunt > Gulp happened. 
Also, karma configurations are not useful for the user installing the library from bower.